### PR TITLE
Fix Compose Previews and persist OneTapSignInState on configuration changes

### DIFF
--- a/onetap/src/main/java/com/stevdzasan/onetap/GoogleUser.kt
+++ b/onetap/src/main/java/com/stevdzasan/onetap/GoogleUser.kt
@@ -1,9 +1,11 @@
 package com.stevdzasan.onetap
 
 import android.util.Log
+import androidx.compose.runtime.Immutable
 import com.auth0.android.jwt.DecodeException
 import com.auth0.android.jwt.JWT
 
+@Immutable
 data class GoogleUser(
     val sub: String?,
     val email: String?,

--- a/onetap/src/main/java/com/stevdzasan/onetap/OneTapCompose.kt
+++ b/onetap/src/main/java/com/stevdzasan/onetap/OneTapCompose.kt
@@ -1,13 +1,15 @@
 package com.stevdzasan.onetap
 
 import android.app.Activity
+import android.content.Context
 import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
 import com.google.android.gms.auth.api.identity.BeginSignInRequest
 import com.google.android.gms.auth.api.identity.Identity
@@ -16,10 +18,12 @@ import com.google.android.gms.common.api.CommonStatusCodes
 
 @Composable
 fun rememberOneTapSignInState(): OneTapSignInState {
-    return remember { OneTapSignInState() }
+    return rememberSaveable(
+        saver = OneTapSignInStateSaver
+    ) { OneTapSignInState() }
 }
 
-const val TAG = "OneTapCompose"
+private const val TAG = "OneTapCompose"
 
 /**
  * Composable that allows you to easily integrate One-Tap Sign in with Google
@@ -45,13 +49,13 @@ fun OneTapSignInWithGoogle(
     onTokenIdReceived: (String) -> Unit,
     onDialogDismissed: (String) -> Unit,
 ) {
-    val activity = LocalContext.current as Activity
+    val context = LocalContext.current
     val activityLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartIntentSenderForResult()
     ) { result ->
         try {
             if (result.resultCode == Activity.RESULT_OK) {
-                val oneTapClient = Identity.getSignInClient(activity)
+                val oneTapClient = Identity.getSignInClient(context)
                 val credentials = oneTapClient.getSignInCredentialFromIntent(result.data)
                 val tokenId = credentials.googleIdToken
                 if (tokenId != null) {
@@ -69,10 +73,12 @@ fun OneTapSignInWithGoogle(
                     onDialogDismissed("Dialog Canceled.")
                     state.close()
                 }
+
                 CommonStatusCodes.NETWORK_ERROR -> {
                     onDialogDismissed("Network Error.")
                     state.close()
                 }
+
                 else -> {
                     onDialogDismissed(e.message.toString())
                     state.close()
@@ -84,7 +90,7 @@ fun OneTapSignInWithGoogle(
     LaunchedEffect(key1 = state.opened) {
         if (state.opened) {
             signIn(
-                activity = activity,
+                context = context,
                 clientId = clientId,
                 rememberAccount = rememberAccount,
                 nonce = nonce,
@@ -101,14 +107,14 @@ fun OneTapSignInWithGoogle(
 }
 
 private fun signIn(
-    activity: Activity,
+    context: Context,
     clientId: String,
     rememberAccount: Boolean,
     nonce: String?,
     launchActivityResult: (IntentSenderRequest) -> Unit,
     onError: (String) -> Unit
 ) {
-    val oneTapClient = Identity.getSignInClient(activity)
+    val oneTapClient = Identity.getSignInClient(context)
     val signInRequest = BeginSignInRequest.builder()
         .setGoogleIdTokenRequestOptions(
             BeginSignInRequest.GoogleIdTokenRequestOptions.builder()
@@ -136,7 +142,7 @@ private fun signIn(
         }
         .addOnFailureListener {
             signUp(
-                activity = activity,
+                context = context,
                 clientId = clientId,
                 nonce = nonce,
                 launchActivityResult = launchActivityResult,
@@ -147,13 +153,13 @@ private fun signIn(
 }
 
 private fun signUp(
-    activity: Activity,
+    context: Context,
     clientId: String,
     nonce: String?,
     launchActivityResult: (IntentSenderRequest) -> Unit,
     onError: (String) -> Unit
 ) {
-    val oneTapClient = Identity.getSignInClient(activity)
+    val oneTapClient = Identity.getSignInClient(context)
     val signInRequest = BeginSignInRequest.builder()
         .setGoogleIdTokenRequestOptions(
             BeginSignInRequest.GoogleIdTokenRequestOptions.builder()
@@ -183,3 +189,8 @@ private fun signUp(
             Log.e(TAG, "${it.message}")
         }
 }
+
+private val OneTapSignInStateSaver: Saver<OneTapSignInState, Boolean> = Saver(
+    save = { state -> state.opened },
+    restore = { opened -> OneTapSignInState(open = opened) },
+)

--- a/onetap/src/main/java/com/stevdzasan/onetap/OneTapSignInState.kt
+++ b/onetap/src/main/java/com/stevdzasan/onetap/OneTapSignInState.kt
@@ -1,11 +1,16 @@
 package com.stevdzasan.onetap
 
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 
-class OneTapSignInState {
-    var opened by mutableStateOf(false)
+/**
+ * @param open Initial value of the state (whether [open] has been invoked)
+ */
+@Stable
+class OneTapSignInState(open: Boolean = false) {
+    var opened by mutableStateOf(open)
         private set
 
     fun open() {


### PR DESCRIPTION
This PR fixes the issue of `OneTapSignInWithGoogle` not being usable in Compose Previews and throwing preview errors like:

```
java.lang.ClassCastException: class com.android.layoutlib.bridge.android.BridgeContext cannot be cast to class android.app.Activity 
(com.android.layoutlib.bridge.android.BridgeContext and android.app.Activity are in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @597d2605)
   at com.stevdzasan.onetap.OneTapComposeKt.OneTapSignInWithGoogle(OneTapCompose.kt:48)
```

This PR also introduces some Compose best practices like:
1. Use `@Stable` and `@Immutable` annotations
2. Introduce a custom `Saver` for `OneTapSignInState` to be used with `rememberSaveable` in order to make `OneTapSignInState` persist configuration changes.