### PR TITLE
Refactor OneTapGoogleButton to Use String Resource for Label

### DIFF
--- a/onetap/src/main/java/com/stevdzasan/onetap/Buttons.kt
+++ b/onetap/src/main/java/com/stevdzasan/onetap/Buttons.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.draw.paint
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -37,6 +38,8 @@ import androidx.compose.ui.unit.dp
  * and quicker sign in process. Set this value to false, if you always want be prompted
  * to select from multiple available accounts.
  * @param nonce Optional nonce that can be used when generating a Google Token ID
+ * @param label The text to be displayed in the label. Supported default languages are EN, DE, ES,
+ * FR, IT, and PT.
  * @param onTokenIdReceived Lambda that will be triggered after a successful
  * authentication. Returns a Token ID.
  * @param onUserReceived This function returns a [GoogleUser] object using the received tokenId.
@@ -57,6 +60,7 @@ fun OneTapGoogleButton(
     state: OneTapSignInState = rememberOneTapSignInState(),
     rememberAccount: Boolean = true,
     nonce: String? = null,
+    label: String = stringResource(id = R.string.label),
     onTokenIdReceived: ((String) -> Unit)? = null,
     onUserReceived: ((GoogleUser) -> Unit)? = null,
     onDialogDismissed: ((String) -> Unit)? = null,
@@ -124,7 +128,7 @@ fun OneTapGoogleButton(
         )
         if (!iconOnly) {
             Text(
-                text = "Sign in with Google",
+                text = label,
                 maxLines = 1,
                 fontFamily = RobotoFontFamily,
             )

--- a/onetap/src/main/res/values-de/strings.xml
+++ b/onetap/src/main/res/values-de/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="label">Mit Google anmelden</string>
+</resources>

--- a/onetap/src/main/res/values-es/strings.xml
+++ b/onetap/src/main/res/values-es/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="label">Acceder con Google</string>
+</resources>

--- a/onetap/src/main/res/values-fr/strings.xml
+++ b/onetap/src/main/res/values-fr/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="label">Se connecter avec Google</string>
+</resources>

--- a/onetap/src/main/res/values-it/strings.xml
+++ b/onetap/src/main/res/values-it/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="label">Accedi con Google</string>
+</resources>

--- a/onetap/src/main/res/values-pt/strings.xml
+++ b/onetap/src/main/res/values-pt/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="label">Fazer login com o Google</string>
+</resources>

--- a/onetap/src/main/res/values/strings.xml
+++ b/onetap/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="label">Sign in with Google</string>
+</resources>


### PR DESCRIPTION
### Summary
This pull request refactors the `OneTapGoogleButton` composable to use a string resource for the label, allowing for better localization and maintainability.

#### Changes
- Replaced the hardcoded "Sign in with Google" text with a string resource reference.
- Added a new `label` parameter to `OneTapGoogleButton` to support localization.
- Updated the documentation to reflect the new `label` parameter.
- Updated imports to include `stringResource`.

#### Benefits
- Improves the maintainability of the code by centralizing the label text.
- Enhances localization support, making it easier to adapt the button text for different languages.

#### Testing
- Verified the button displays the correct label text in different themes (Light, Dark, Neutral).

#### Screenshots
![de](https://github.com/user-attachments/assets/ca970a7c-4842-4902-bfc5-3d8a1f81fc64)
![en](https://github.com/user-attachments/assets/ed4b6981-592f-4a85-9354-6f90273daaa4)
![it](https://github.com/user-attachments/assets/66c3b8b4-6dc0-4519-9d49-0eab6a91dea1)
![pt](https://github.com/user-attachments/assets/31676c87-5b62-4c06-8720-6240f97c26ba)
![fr](https://github.com/user-attachments/assets/31e63c0a-518e-4792-a7d6-92e5707947e3)
![es](https://github.com/user-attachments/assets/f4666789-7339-4e03-9d74-d00ff148340a)

Please review the changes and provide any feedback.